### PR TITLE
#413

### DIFF
--- a/OpenJMLTest/.gitignore
+++ b/OpenJMLTest/.gitignore
@@ -2,3 +2,5 @@
 /temp-release/
 /benchmarks/
 /testdata/
+/test/**/actual
+/test/**/actual-compile

--- a/OpenJMLTest/src/org/jmlspecs/openjmltest/testcases/racfiles.java
+++ b/OpenJMLTest/src/org/jmlspecs/openjmltest/testcases/racfiles.java
@@ -286,7 +286,7 @@ public class racfiles extends RacBase {
     @Test
     public void sfbug413() {
         expectedRACExit = 0;
-        helpTCF("test/sfbug413","test/sfbug413","Main","-show");
+        helpTCF("test/sfbug413","test/sfbug413","Main");
     }
 
 


### PR DESCRIPTION
It turns out that the problem was that nested type envs do not automatically update inside of the enter.typeEnvs structure, which is used extensively during the desugaring process. 

Perhaps there is a more elegant way to update these references, but this is what was obvious right away. 
