### PR TITLE
Fixed #462 (the instanceof error case)

### DIFF
--- a/OpenJML/src/org/jmlspecs/openjml/JmlTreeUtils.java
+++ b/OpenJML/src/org/jmlspecs/openjml/JmlTreeUtils.java
@@ -1112,6 +1112,13 @@ public class JmlTreeUtils {
     public JCExpression makeDynamicTypeInEquality(DiagnosticPosition pos, JCExpression id, Type type) {
         int p = pos.getPreferredPosition();
         JCExpression nn = makeEqObject(p,id,nullLit);
+        
+        return makeOr(p,nn,makeNonNullDynamicTypeInEquality(pos, id, type));
+    }
+    
+    /** Returns the AST for \typeof(id) <: \type(type) && id instanceof 'erasure of type' */
+    public JCExpression makeNonNullDynamicTypeInEquality(DiagnosticPosition pos, JCExpression id, Type type) {
+        int p = pos.getPreferredPosition();
         JCExpression lhs = makeTypeof(id); // FIXME - copy?
         JmlMethodInvocation rhs = factory.at(p).JmlMethodInvocation(JmlToken.BSTYPELC,makeType(p,type));
         rhs.type = JmlTypes.instance(context).TYPE;
@@ -1131,7 +1138,7 @@ public class JmlTreeUtils {
                 expr = makeAnd(p,expr,e);
             }
         }
-        return makeOr(p,nn,expr);
+        return expr;
     }
     
     /** Creates an AST for an invocation of a (static) method in org.jmlspecs.utils.Utils,

--- a/OpenJML/src/org/jmlspecs/openjml/esc/JmlAssertionAdder.java
+++ b/OpenJML/src/org/jmlspecs/openjml/esc/JmlAssertionAdder.java
@@ -2086,7 +2086,9 @@ public class JmlAssertionAdder extends JmlTreeScanner {
                         JCExpression e;
                         if (receiver == null) e = M.at(pos).Ident(v);
                         else e = M.at(pos).Select(receiver, v);
-                        e = treeutils.makeNotNull(pos.getStartPosition(),e); // FIXME - position not right
+                        JCExpression e1 = treeutils.makeNotNull(pos.getStartPosition(),e); // FIXME - position not right
+                        JCExpression e2 = treeutils.makeNonNullDynamicTypeInEquality(pos, e, e.type);
+                        e = treeutils.makeAnd(pos.getStartPosition(), e1, e2); // FIXME - position not right
                         if (assume) addAssume(pos,Label.POSSIBLY_NULL_VALUE,
                                 e,
                                 null,null); // FIXME - no associated position?

--- a/OpenJMLTest/test/gitbug462/expected
+++ b/OpenJMLTest/test/gitbug462/expected
@@ -9,6 +9,7 @@ Feasibility check #2 - at program exit : OK
 Completed proof of Container.allocate() with prover !!!! - no warnings
 Starting proof of Container.test() with prover !!!!
 Feasibility check #1 - end of preconditions : OK
-Feasibility check #2 - at program exit : OK
+Feasibility check #2 - before explicit assert statement : OK
+Feasibility check #3 - at program exit : OK
 Completed proof of Container.test() with prover !!!! - no warnings
 Completed proving methods in Container


### PR DESCRIPTION
Note that this increases the overall number of failures in the test suite because, while it fixes #462, it also induces the bug described in #467 with all provers, and not just with provers that are not Z3 4.3.

#462 also describes an error with using \fresh. This change does not fix that part of the bug report.