### PR TITLE
Implicit record fields

### DIFF
--- a/OpenJMLTest/src/org/jmlspecs/openjmltest/testsuites/escrecord.java
+++ b/OpenJMLTest/src/org/jmlspecs/openjmltest/testsuites/escrecord.java
@@ -1,0 +1,406 @@
+package org.jmlspecs.openjmltest.testsuites;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import javax.tools.JavaFileObject;
+
+import org.jmlspecs.openjmltest.EscBase;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.openjml.MockJavaFileObject;
+
+import com.sun.tools.javac.util.List;
+
+@org.junit.FixMethodOrder(org.junit.runners.MethodSorters.NAME_ASCENDING)
+@RunWith(org.openjml.runners.ParameterizedWithNames.class)
+public class escrecord extends EscBase {
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        addOptions("--check-feasibility=none");
+        expectedExit = 0;
+    }
+
+    /**
+     * Compiles the given source and asserts that no internal JML/OpenJML error
+     * occurred.
+     */
+    private void assertNoInternalError(String filename, String source) throws Exception {
+        JavaFileObject f = new MockJavaFileObject(filename, source);
+        main.compile(new String[]{}, List.of(f));
+        String diags = diagnosticsToString(collector.getDiagnostics());
+        assertFalse("Did not expect a catastrophic internal error:\n" + diags,
+                diags.contains("A catastrophic JML internal error occurred"));
+        assertFalse("Did not expect an internal JML error:\n" + diags,
+                diags.contains("An internal JML error occurred"));
+    }
+
+    /**
+     * Compiles and asserts zero verification warnings (clean pass).
+     */
+    private void assertCleanVerification(String qualifiedName, String source) {
+        helpEsc(qualifiedName, source);
+    }
+
+    // =======================================================================
+    //  Category 1: Basic record field assignment — the core Bug C fix
+    // =======================================================================
+
+    /** Compact constructor with non_null fields verified by requireNonNull. */
+    @Test
+    public void testRecordCompactNonNull() {
+        assertCleanVerification("tt.A", """
+                package tt;
+                import org.jmlspecs.annotation.*;
+                public class A {
+                    record Name(/*@ non_null */ String first, /*@ non_null */ String last) {
+                        Name {
+                            java.util.Objects.requireNonNull(first);
+                            java.util.Objects.requireNonNull(last);
+                        }
+                    }
+                }
+                """);
+    }
+
+    /** Primitive record fields — should always verify cleanly. */
+    @Test
+    public void testRecordPrimitiveFields() {
+        assertCleanVerification("tt.A", """
+                package tt;
+                public class A {
+                    record Point(int x, int y) {}
+                }
+                """);
+    }
+
+    /** Record with a single primitive field. */
+    @Test
+    public void testRecordSinglePrimitive() {
+        assertCleanVerification("tt.A", """
+                package tt;
+                public class A {
+                    record Wrapper(int value) {}
+                }
+                """);
+    }
+
+    /** Generated (canonical) constructor with non_null reference field. */
+    @Test
+    public void testRecordGeneratedConstructorNonNull() {
+        assertCleanVerification("tt.A", """
+                package tt;
+                import org.jmlspecs.annotation.*;
+                public class A {
+                    record Box(/*@ non_null */ Object item) {}
+                }
+                """);
+    }
+
+    /** Compact constructor with empty body — fields should still be assigned. */
+    @Test
+    public void testRecordCompactEmptyBody() {
+        assertCleanVerification("tt.A", """
+                package tt;
+                import org.jmlspecs.annotation.*;
+                public class A {
+                    record Pair(/*@ non_null */ Object a, /*@ non_null */ Object b) {
+                        Pair {}
+                    }
+                }
+                """);
+    }
+
+    /** Mixed primitive and reference fields. */
+    @Test
+    public void testRecordMixedFields() {
+        assertCleanVerification("tt.A", """
+                package tt;
+                import org.jmlspecs.annotation.*;
+                public class A {
+                    record Entry(/*@ non_null */ String key, int value) {
+                        Entry {
+                            java.util.Objects.requireNonNull(key);
+                        }
+                    }
+                }
+                """);
+    }
+
+    // =======================================================================
+    //  Category 2: Compact body interactions
+    // =======================================================================
+
+    /** Compact constructor that validates with requireNonNull. */
+    @Test
+    public void testRecordCompactRequireNonNull() {
+        assertCleanVerification("tt.A", """
+                package tt;
+                import org.jmlspecs.annotation.*;
+                public class A {
+                    record Config(/*@ non_null */ String name, int timeout) {
+                        Config {
+                            java.util.Objects.requireNonNull(name, "name must not be null");
+                            if (timeout < 0) throw new IllegalArgumentException("timeout < 0");
+                        }
+                    }
+                }
+                """);
+    }
+
+    /** Compact body that reassigns a parameter (normalizing). */
+    @Test
+    public void testRecordCompactParamTransform() {
+        assertCleanVerification("tt.A", """
+                package tt;
+                import org.jmlspecs.annotation.*;
+                public class A {
+                    record Label(/*@ non_null */ String text) {
+                        Label {
+                            java.util.Objects.requireNonNull(text);
+                            text = text.trim();
+                        }
+                    }
+                }
+                """);
+    }
+
+    /** Compact constructor with range validation on primitives. */
+    @Test
+    public void testRecordCompactRangeValidation() {
+        assertCleanVerification("tt.A", """
+                package tt;
+                public class A {
+                    record Range(int lo, int hi) {
+                        Range {
+                            if (lo > hi) throw new IllegalArgumentException();
+                        }
+                    }
+                }
+                """);
+    }
+
+    // =======================================================================
+    //  Category 3: Record method field access
+    // =======================================================================
+
+    /** Record accessor methods can assume field invariants. */
+    @Test
+    public void testRecordMethodFieldAccess() throws Exception {
+        assertNoInternalError("A.java", """
+                import org.jmlspecs.annotation.*;
+                class A {
+                    record Name(/*@ non_null */ String first, /*@ non_null */ String last) {
+                        Name {
+                            java.util.Objects.requireNonNull(first);
+                            java.util.Objects.requireNonNull(last);
+                        }
+                        //@ ensures \\result != null;
+                        /*@ pure */ String fullName() {
+                            return first + " " + last;
+                        }
+                    }
+                }
+                """);
+    }
+
+    // =======================================================================
+    //  Category 4: Generic type parameters on records
+    // =======================================================================
+
+    /** Record with a generic type parameter — nullable reference. */
+    @Test
+    public void testRecordGenericNullable() throws Exception {
+        assertNoInternalError("A.java", """
+                class A {
+                    record Container<T>(/*@ nullable */ T value) {}
+                }
+                """);
+    }
+
+    /** Record with bounded generic type parameter. */
+    @Test
+    public void testRecordGenericBounded() throws Exception {
+        assertNoInternalError("A.java", """
+                class A {
+                    record NumBox<N extends Number>(/*@ non_null */ N num) {
+                        NumBox {
+                            java.util.Objects.requireNonNull(num);
+                        }
+                    }
+                }
+                """);
+    }
+
+    /** Record with multiple generic type parameters. */
+    @Test
+    public void testRecordMultipleGenerics() throws Exception {
+        assertNoInternalError("A.java", """
+                class A {
+                    record Pair<A1, B1>(/*@ nullable */ A1 first, /*@ nullable */ B1 second) {}
+                }
+                """);
+    }
+
+    // =======================================================================
+    //  Category 5: Records with JML annotations
+    // =======================================================================
+
+    /** Record with a JML invariant on a field. */
+    @Test
+    public void testRecordInvariant() {
+        assertCleanVerification("tt.A", """
+                package tt;
+                public class A {
+                    record Positive(int value) {
+                        //@ private invariant value > 0;
+                        Positive {
+                            if (value <= 0) throw new IllegalArgumentException();
+                        }
+                    }
+                }
+                """);
+    }
+
+    /** Record with ensures on the compact constructor. */
+    @Test
+    public void testRecordEnsures() {
+        assertCleanVerification("tt.A", """
+                package tt;
+                import org.jmlspecs.annotation.*;
+                public class A {
+                    record NonEmpty(/*@ non_null */ String text) {
+                        //@ ensures text != null;
+                        NonEmpty {
+                            java.util.Objects.requireNonNull(text);
+                        }
+                    }
+                }
+                """);
+    }
+
+    /** Pure record method. */
+    @Test
+    public void testRecordPureMethod() throws Exception {
+        assertNoInternalError("A.java", """
+                import org.jmlspecs.annotation.*;
+                class A {
+                    record IntPair(int x, int y) {
+                        /*@ pure */ int sum() { return x + y; }
+                    }
+                }
+                """);
+    }
+
+    // =======================================================================
+    //  Category 6: Sealed interfaces with records
+    // =======================================================================
+
+    /** Simple sealed interface with record implementations. */
+    @Test
+    public void testRecordSealedInterface() throws Exception {
+        assertNoInternalError("A.java", """
+                import org.jmlspecs.annotation.*;
+                class A {
+                    sealed interface Shape permits Circle, Rect {}
+                    record Circle(double radius) implements Shape {
+                        Circle {
+                            if (radius < 0) throw new IllegalArgumentException();
+                        }
+                    }
+                    record Rect(double w, double h) implements Shape {
+                        Rect {
+                            if (w < 0 || h < 0) throw new IllegalArgumentException();
+                        }
+                    }
+                }
+                """);
+    }
+
+    /** Record implementing multiple interfaces. */
+    @Test
+    public void testRecordMultipleInterfaces() throws Exception {
+        assertNoInternalError("A.java", """
+                class A {
+                    interface Named { String name(); }
+                    record Person(/*@ nullable */ String name, int age) implements Named {}
+                }
+                """);
+    }
+
+    // =======================================================================
+    //  Category 7: Regression — regular classes should be unaffected
+    // =======================================================================
+
+    /** Regular class with constructor and non_null field — not a record. */
+    @Test
+    public void testRegularClassUnaffected() {
+        assertCleanVerification("tt.A", """
+                package tt;
+                import org.jmlspecs.annotation.*;
+                public class A {
+                    /*@ spec_public non_null */ String name;
+                    //@ ensures this.name == n;
+                    public A(/*@ non_null */ String n) {
+                        this.name = n;
+                    }
+                }
+                """);
+    }
+
+    /** Regular class with nullable field — unchanged semantics. */
+    @Test
+    public void testRegularClassNullableField() {
+        assertCleanVerification("tt.A", """
+                package tt;
+                import org.jmlspecs.annotation.*;
+                public class A {
+                    /*@ nullable */ String label;
+                    public A() {
+                        this.label = null;
+                    }
+                }
+                """);
+    }
+
+    /** Static fields in records — should NOT be affected by the fix. */
+    @Test
+    public void testRecordStaticFieldUnaffected() throws Exception {
+        assertNoInternalError("A.java", """
+                class A {
+                    record Config(int value) {
+                        static final int DEFAULT = 42;
+                    }
+                }
+                """);
+    }
+
+    /** Record with no fields (empty record). */
+    @Test
+    public void testRecordNoFields() {
+        assertCleanVerification("tt.A", """
+                package tt;
+                public class A {
+                    record Empty() {}
+                }
+                """);
+    }
+
+    /** Multiple records in same file. */
+    @Test
+    public void testMultipleRecordsInFile() throws Exception {
+        assertNoInternalError("A.java", """
+                import org.jmlspecs.annotation.*;
+                class A {
+                    record Ok<T>(/*@ non_null */ T value) {
+                        Ok { java.util.Objects.requireNonNull(value); }
+                    }
+                    record Err<E>(/*@ non_null */ E error) {
+                        Err { java.util.Objects.requireNonNull(error); }
+                    }
+                }
+                """);
+    }
+}

--- a/OpenJMLTest/src/org/jmlspecs/openjmltest/testsuites/escswitch.java
+++ b/OpenJMLTest/src/org/jmlspecs/openjmltest/testsuites/escswitch.java
@@ -22,8 +22,41 @@ public class escswitch extends EscBase {
         super.setUp();
         addOptions("--source", "21");
         addOptions("--enable-preview", "--enable-preview");
+        addOptions("--check-feasibility=none");
         expectedExit = 0;
     }
+
+    /**
+     * Compiles the given source and asserts that no internal JML/OpenJML error
+     * occurred.  Accepts a clean exit (0) or the known missing-prover message
+     * when z3 is unavailable in the test environment.
+     */
+    private void assertNoInternalError(String filename, String source) throws Exception {
+        assertNoInternalError(filename, source, null);
+    }
+
+    private void assertNoInternalError(String filename, String source, String method) throws Exception {
+        if (method != null) addOptions("--method=" + method);
+        JavaFileObject f = new MockJavaFileObject(filename, source);
+        int ex = main.compile(new String[]{}, List.of(f)).exitCode;
+        String diags = diagnosticsToString(collector.getDiagnostics());
+        assertFalse("Did not expect a catastrophic internal error:\n" + diags,
+                diags.contains("A catastrophic JML internal error occurred"));
+        assertFalse("Did not expect an internal JML error:\n" + diags,
+                diags.contains("An internal JML error occurred"));
+        assertFalse("Did not expect a null-expression crash in the SMT writer:\n" + diags,
+                diags.contains("C_define_fun.expression()\" is null"));
+        assertFalse("Did not expect the concat regression:\n" + diags,
+                diags.contains("Could not find the concat method"));
+        assertFalse("Did not expect a null-arg regression:\n" + diags,
+                diags.contains("Cannot read field \"type\" because \"a\" is null"));
+        assertTrue("Expected either a clean compile or only the known missing-prover failure, got:\n" + diags,
+                ex == 0 || diags.contains("The executable for prover z3_4_3 is not specified"));
+    }
+
+    // -----------------------------------------------------------------------
+    //  Bug-2 regression: switch expression with throw arm
+    // -----------------------------------------------------------------------
 
     /** Minimal sealed Result type exercising record-pattern switch and binding-pattern switch. */
     static final String RESULT_SOURCE = """
@@ -50,24 +83,233 @@ public class escswitch extends EscBase {
             }
             """;
 
+    /** The original crash: switch expression with a record-pattern yield arm and a throw arm. */
     @Test
-    public void testResultRegression() throws Exception {
-        addOptions("--check-feasibility=none");
-        addOptions("--method=getChecked");
-        JavaFileObject result = new MockJavaFileObject(
-                "com/kevel/util/Result.java",
-                RESULT_SOURCE);
-        int ex = main.compile(new String[]{}, List.of(result)).exitCode;
-        String diags = diagnosticsToString(collector.getDiagnostics());
-        assertFalse("Did not expect a catastrophic internal error:\n" + diags,
-                diags.contains("A catastrophic JML internal error occurred"));
-        assertFalse("Did not expect the previous concat regression:\n" + diags,
-                diags.contains("Could not find the concat method"));
-        assertFalse("Did not expect the previous null-arg regression:\n" + diags,
-                diags.contains("Cannot read field \"type\" because \"a\" is null"));
-        assertFalse("Did not expect the previous regression to trigger any internal JML error:\n" + diags,
-                diags.contains("An internal JML error occurred"));
-        assertTrue("Expected either a clean compile or only the known missing-prover failure, got:\n" + diags,
-                ex == 0 || diags.contains("The executable for prover z3_4_3 is not specified"));
+    public void testResultGetChecked() throws Exception {
+        assertNoInternalError("com/example/Result.java", RESULT_SOURCE, "getChecked");
+    }
+
+    /** The binding-pattern arm with a default fallback. */
+    @Test
+    public void testResultGet() throws Exception {
+        assertNoInternalError("com/example/Result.java", RESULT_SOURCE, "get");
+    }
+
+    // -----------------------------------------------------------------------
+    //  Pattern switch expression: binding patterns
+    // -----------------------------------------------------------------------
+
+    /** Switch expression with a simple binding pattern and a default. */
+    @Test
+    public void testBindingPatternSwitchExpr() throws Exception {
+        assertNoInternalError("A.java", """
+                class A {
+                    int m(Object o) {
+                        return switch (o) {
+                            case String s -> s.length();
+                            default -> 0;
+                        };
+                    }
+                }
+                """);
+    }
+
+    /** Exhaustive binding-pattern switch over a sealed interface. */
+    @Test
+    public void testSealedBindingPatternExhaustive() throws Exception {
+        assertNoInternalError("A.java", """
+                class A {
+                    sealed interface Shape permits Circle, Rect {}
+                    record Circle(double r) implements Shape {}
+                    record Rect(double w, double h) implements Shape {}
+
+                    double area(Shape s) {
+                        return switch (s) {
+                            case Circle c -> 3.14 * c.r() * c.r();
+                            case Rect r   -> r.w() * r.h();
+                        };
+                    }
+                }
+                """);
+    }
+
+    // -----------------------------------------------------------------------
+    //  Pattern switch expression: record patterns
+    // -----------------------------------------------------------------------
+
+    /** Switch expression with record patterns that destructure a record.
+     *  Uses reference types (Integer) to avoid the pre-existing SMT sort-mismatch
+     *  bug with primitive-typed record pattern components.
+     *  Avoids int arithmetic to sidestep overflow verification warnings. */
+    @Test
+    public void testRecordPatternSwitchExpr() throws Exception {
+        assertNoInternalError("A.java", """
+                class A {
+                    sealed interface Expr permits Lit, Neg {}
+                    record Lit(String value) implements Expr {}
+                    record Neg(Expr inner) implements Expr {}
+
+                    String show(Expr e) {
+                        return switch (e) {
+                            case Lit(String v) -> v;
+                            case Neg(Expr inner) -> "-" + show(inner);
+                        };
+                    }
+                }
+                """);
+    }
+
+    /** Record-pattern switch with a throw in one arm (the core Bug-2 scenario). */
+    @Test
+    public void testRecordPatternWithThrowArm() throws Exception {
+        assertNoInternalError("A.java", """
+                class A {
+                    sealed interface Try<T> permits Ok, Fail {}
+                    record Ok<T>(T value) implements Try<T> {}
+                    record Fail<T>(RuntimeException ex) implements Try<T> {}
+
+                    static <T> T unwrap(Try<T> t) {
+                        return switch (t) {
+                            case Ok<T>(var v)  -> v;
+                            case Fail<T>(var e) -> throw e;
+                        };
+                    }
+                }
+                """);
+    }
+
+    // -----------------------------------------------------------------------
+    //  Pattern switch expression: guarded patterns (when clause)
+    // -----------------------------------------------------------------------
+
+    /** Switch expression with guarded record patterns.
+     *  Uses Integer (reference type) to avoid the pre-existing SMT sort-mismatch
+     *  bug with primitive-typed record pattern components. */
+    @Test
+    public void testGuardedPatternSwitchExpr() throws Exception {
+        assertNoInternalError("A.java", """
+                class A {
+                    record Box(Integer x) {}
+
+                    int classify(Box b) {
+                        return switch (b) {
+                            case Box(Integer x) when x > 0  -> 1;
+                            case Box(Integer x) when x == 0 -> 0;
+                            case Box(Integer x)             -> -1;
+                        };
+                    }
+                }
+                """);
+    }
+
+    // -----------------------------------------------------------------------
+    //  Pattern switch expression: mixed constant + pattern labels
+    // -----------------------------------------------------------------------
+
+    /** Switch expression mixing null, constant and pattern labels. */
+    @Test
+    public void testMixedConstantAndPatternLabels() throws Exception {
+        assertNoInternalError("A.java", """
+                class A {
+                    String describe(Object o) {
+                        return switch (o) {
+                            case Integer i -> "int: " + i;
+                            case String s  -> "str: " + s;
+                            case null, default -> "other";
+                        };
+                    }
+                }
+                """);
+    }
+
+    // -----------------------------------------------------------------------
+    //  Pattern switch *statement* (not expression)
+    // -----------------------------------------------------------------------
+
+    /** Pattern switch statement — verifies BasicBlocker handles pattern cases
+     *  correctly even when the switch is not an expression. */
+    @Test
+    public void testPatternSwitchStatement() throws Exception {
+        assertNoInternalError("A.java", """
+                class A {
+                    sealed interface Animal permits Dog, Cat {}
+                    record Dog(String name) implements Animal {}
+                    record Cat(String name) implements Animal {}
+
+                    void greet(Animal a) {
+                        switch (a) {
+                            case Dog d -> System.out.println("Woof, " + d.name());
+                            case Cat c -> System.out.println("Meow, " + c.name());
+                        }
+                    }
+                }
+                """);
+    }
+
+    /** Pattern switch statement with a throw in one arm. */
+    @Test
+    public void testPatternSwitchStatementWithThrow() throws Exception {
+        assertNoInternalError("A.java", """
+                class A {
+                    sealed interface Validated<T> permits Valid, Invalid {}
+                    record Valid<T>(T value) implements Validated<T> {}
+                    record Invalid<T>(String msg) implements Validated<T> {}
+
+                    static <T> void process(Validated<T> v) {
+                        switch (v) {
+                            case Valid<T>(var val)    -> System.out.println(val);
+                            case Invalid<T>(var msg) -> throw new IllegalArgumentException(msg);
+                        }
+                    }
+                }
+                """);
+    }
+
+    // -----------------------------------------------------------------------
+    //  Pattern switch expression: default with pattern arms
+    // -----------------------------------------------------------------------
+
+    /** Switch expression with pattern arms + explicit default. */
+    @Test
+    public void testPatternSwitchExprWithDefault() throws Exception {
+        assertNoInternalError("A.java", """
+                class A {
+                    int measure(Object o) {
+                        return switch (o) {
+                            case String s  -> s.length();
+                            case Integer i -> i;
+                            default        -> -1;
+                        };
+                    }
+                }
+                """);
+    }
+
+    // -----------------------------------------------------------------------
+    //  Multiple throw arms
+    // -----------------------------------------------------------------------
+
+    /** Switch expression where all-but-one arm throws — verifies that the
+     *  throw-arm pattern handling in BasicBlocker doesn't crash.
+     *  (A switch expression where literally *every* arm throws is rejected by
+     *  javac with "switch expression does not have any result expressions".) */
+    @Test
+    public void testAllArmsThrow() throws Exception {
+        assertNoInternalError("A.java", """
+                class A {
+                    sealed interface Status permits StatusA, StatusB, StatusC {}
+                    record StatusA(String msg) implements Status {}
+                    record StatusB(String msg) implements Status {}
+                    record StatusC(String msg) implements Status {}
+
+                    static int fail(Status s) {
+                        return switch (s) {
+                            case StatusA(var m) -> throw new UnsupportedOperationException(m);
+                            case StatusB(var m) -> throw new UnsupportedOperationException(m);
+                            case StatusC(var m) -> 0;
+                        };
+                    }
+                }
+                """);
     }
 }

--- a/OpenJMLTest/src/org/jmlspecs/openjmltest/testsuites/escswitch.java
+++ b/OpenJMLTest/src/org/jmlspecs/openjmltest/testsuites/escswitch.java
@@ -1,0 +1,73 @@
+package org.jmlspecs.openjmltest.testsuites;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import javax.tools.JavaFileObject;
+
+import org.jmlspecs.openjmltest.EscBase;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.openjml.MockJavaFileObject;
+import org.openjml.runners.ParameterizedWithNames;
+
+import com.sun.tools.javac.util.List;
+
+@org.junit.FixMethodOrder(org.junit.runners.MethodSorters.NAME_ASCENDING)
+@RunWith(ParameterizedWithNames.class)
+public class escswitch extends EscBase {
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        addOptions("--source", "21");
+        addOptions("--enable-preview", "--enable-preview");
+        expectedExit = 0;
+    }
+
+    /** Minimal sealed Result type exercising record-pattern switch and binding-pattern switch. */
+    static final String RESULT_SOURCE = """
+            package com.example;
+
+            public sealed interface Result<T, E> permits Result.Ok, Result.Err {
+
+                record Ok<T, E>(T value) implements Result<T, E> {}
+                record Err<T, E>(E error) implements Result<T, E> {}
+
+                static <T, E extends Throwable> T getChecked(Result<T, E> result) throws E {
+                    return switch (result) {
+                        case Ok<T, E>(var value) -> value;
+                        case Err<T, E>(var error) -> throw error;
+                    };
+                }
+
+                static <T, E> T get(Result<T, E> result) {
+                    return switch (result) {
+                        case Ok<T, E> ok -> ok.value();
+                        default -> null;
+                    };
+                }
+            }
+            """;
+
+    @Test
+    public void testResultRegression() throws Exception {
+        addOptions("--check-feasibility=none");
+        addOptions("--method=getChecked");
+        JavaFileObject result = new MockJavaFileObject(
+                "com/kevel/util/Result.java",
+                RESULT_SOURCE);
+        int ex = main.compile(new String[]{}, List.of(result)).exitCode;
+        String diags = diagnosticsToString(collector.getDiagnostics());
+        assertFalse("Did not expect a catastrophic internal error:\n" + diags,
+                diags.contains("A catastrophic JML internal error occurred"));
+        assertFalse("Did not expect the previous concat regression:\n" + diags,
+                diags.contains("Could not find the concat method"));
+        assertFalse("Did not expect the previous null-arg regression:\n" + diags,
+                diags.contains("Cannot read field \"type\" because \"a\" is null"));
+        assertFalse("Did not expect the previous regression to trigger any internal JML error:\n" + diags,
+                diags.contains("An internal JML error occurred"));
+        assertTrue("Expected either a clean compile or only the known missing-prover failure, got:\n" + diags,
+                ex == 0 || diags.contains("The executable for prover z3_4_3 is not specified"));
+    }
+}

--- a/OpenJMLTest/src/org/jmlspecs/openjmltest/testsuites/esctwr.java
+++ b/OpenJMLTest/src/org/jmlspecs/openjmltest/testsuites/esctwr.java
@@ -1,0 +1,342 @@
+package org.jmlspecs.openjmltest.testsuites;
+
+import static org.junit.Assert.assertFalse;
+
+import javax.tools.JavaFileObject;
+
+import org.jmlspecs.openjmltest.EscBase;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.openjml.MockJavaFileObject;
+import org.openjml.runners.ParameterizedWithNames;
+
+import com.sun.tools.javac.util.List;
+
+@org.junit.FixMethodOrder(org.junit.runners.MethodSorters.NAME_ASCENDING)
+@RunWith(ParameterizedWithNames.class)
+public class esctwr extends EscBase {
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        addOptions("--check-feasibility=none");
+        expectedExit = 0;
+    }
+
+    /**
+     * Compiles the given source and asserts that no internal JML/OpenJML error
+     * occurred.  Accepts a clean exit (0) or the known missing-prover message
+     * when z3 is unavailable in the test environment.
+     */
+    private void assertNoInternalError(String filename, String source) throws Exception {
+        assertNoInternalError(filename, source, null);
+    }
+
+    private void assertNoInternalError(String filename, String source, String method) throws Exception {
+        if (method != null) addOptions("--method=" + method);
+        JavaFileObject f = new MockJavaFileObject(filename, source);
+        main.compile(new String[]{}, List.of(f));
+        String diags = diagnosticsToString(collector.getDiagnostics());
+        assertFalse("Did not expect a catastrophic internal error:\n" + diags,
+                diags.contains("A catastrophic JML internal error occurred"));
+        assertFalse("Did not expect an internal JML error:\n" + diags,
+                diags.contains("An internal JML error occurred"));
+        assertFalse("Did not expect a ClassCastException (JCIdent to JCVariableDecl):\n" + diags,
+                diags.contains("JCIdent cannot be cast to") && diags.contains("JCVariableDecl"));
+        assertFalse("Did not expect a ClassCastException (TypeVariableSymbol to ClassSymbol):\n" + diags,
+                diags.contains("TypeVariableSymbol cannot be cast to") && diags.contains("ClassSymbol"));
+        assertFalse("Did not expect a ClassCastException (JCFieldAccess to JCVariableDecl):\n" + diags,
+                diags.contains("JCFieldAccess cannot be cast to") && diags.contains("JCVariableDecl"));
+        // We do NOT assert on exit code: verification warnings (ExceptionList,
+        // InvariantEntrance, etc.) produce a non-zero exit, which is fine.
+        // The point of these tests is that no ClassCastException / internal
+        // error occurs — normal verification output is acceptable.
+    }
+
+    // -----------------------------------------------------------------------
+    //  Bug A: expression resource (JCIdent) — Java 9+ try-with-resources
+    //  Previously crashed with: JCIdent cannot be cast to JCVariableDecl
+    // -----------------------------------------------------------------------
+
+    /** Expression resource with a concrete AutoCloseable type. */
+    @Test
+    public void testTwrExpressionResource() throws Exception {
+        assertNoInternalError("A.java", """
+                import java.io.*;
+                class A {
+                    void process(BufferedReader br) throws IOException {
+                        try (br) {
+                            System.out.println(br.readLine());
+                        }
+                    }
+                }
+                """);
+    }
+
+    /** Expression resource with a concrete type implementing Closeable. */
+    @Test
+    public void testTwrExpressionResourceCloseable() throws Exception {
+        assertNoInternalError("A.java", """
+                import java.io.*;
+                class A {
+                    void process(InputStream in) throws IOException {
+                        try (in) {
+                            in.read();
+                        }
+                    }
+                }
+                """);
+    }
+
+    /** Multiple expression resources in one try statement. */
+    @Test
+    public void testTwrMultipleExpressionResources() throws Exception {
+        assertNoInternalError("A.java", """
+                import java.io.*;
+                class A {
+                    void copy(InputStream in, OutputStream out) throws IOException {
+                        try (in; out) {
+                            out.write(in.read());
+                        }
+                    }
+                }
+                """);
+    }
+
+    // -----------------------------------------------------------------------
+    //  Bug B: generic resource type (TypeVariableSymbol)
+    //  Previously crashed with: TypeVariableSymbol cannot be cast to ClassSymbol
+    // -----------------------------------------------------------------------
+
+    /** Traditional declaration with a Closeable-bounded type variable. */
+    @Test
+    public void testTwrGenericResourceCloseable() throws Exception {
+        assertNoInternalError("A.java", """
+                import java.io.*;
+                class A {
+                    static <R extends Closeable> void use(R resource) throws IOException {
+                        try (R r = resource) {
+                            System.out.println(r);
+                        }
+                    }
+                }
+                """);
+    }
+
+    /** Traditional declaration with an AutoCloseable-bounded type variable. */
+    @Test
+    public void testTwrGenericResourceAutoCloseable() throws Exception {
+        assertNoInternalError("A.java", """
+                class A {
+                    static <R extends AutoCloseable> void use(R resource) throws Exception {
+                        try (R r = resource) {
+                            System.out.println(r);
+                        }
+                    }
+                }
+                """);
+    }
+
+    /** Multiple type parameters, one is the resource type. */
+    @Test
+    public void testTwrGenericResourceMultipleTypeParams() throws Exception {
+        assertNoInternalError("A.java", """
+                import java.io.*;
+                class A {
+                    static <T, R extends Closeable> void process(T data, R resource) throws IOException {
+                        try (R r = resource) {
+                            System.out.println(data);
+                        }
+                    }
+                }
+                """);
+    }
+
+    // -----------------------------------------------------------------------
+    //  Bug A + Bug B combined: expression resource with generic type
+    //  Triggers both bugs simultaneously
+    // -----------------------------------------------------------------------
+
+    /** Expression resource with a generic type variable. */
+    @Test
+    public void testTwrExpressionGenericResource() throws Exception {
+        assertNoInternalError("A.java", """
+                import java.io.*;
+                class A {
+                    static <R extends Closeable> void use(R resource) throws IOException {
+                        try (resource) {
+                            System.out.println(resource);
+                        }
+                    }
+                }
+                """);
+    }
+
+    /** Expression resource with AutoCloseable-bounded generic type. */
+    @Test
+    public void testTwrExpressionGenericAutoCloseable() throws Exception {
+        assertNoInternalError("A.java", """
+                class A {
+                    static <R extends AutoCloseable> void use(R resource) throws Exception {
+                        try (resource) {
+                            System.out.println(resource);
+                        }
+                    }
+                }
+                """);
+    }
+
+    // -----------------------------------------------------------------------
+    //  Field access resources (JCFieldAccess variant of Bug A)
+    // -----------------------------------------------------------------------
+
+    /** Expression resource via field access: this.resource. */
+    @Test
+    public void testTwrFieldAccessResource() throws Exception {
+        assertNoInternalError("A.java", """
+                import java.io.*;
+                class A {
+                    final InputStream stream;
+                    A(InputStream s) { this.stream = s; }
+                    void process() throws IOException {
+                        try (this.stream) {
+                            stream.read();
+                        }
+                    }
+                }
+                """);
+    }
+
+    // -----------------------------------------------------------------------
+    //  Mixed resources: declaration + expression in one try
+    // -----------------------------------------------------------------------
+
+    /** Mixed declaration and expression resources in one try statement. */
+    @Test
+    public void testTwrMixedResources() throws Exception {
+        assertNoInternalError("A.java", """
+                import java.io.*;
+                class A {
+                    void process(InputStream existing) throws IOException {
+                        try (existing;
+                             BufferedReader br = new BufferedReader(new InputStreamReader(existing))) {
+                            System.out.println(br.readLine());
+                        }
+                    }
+                }
+                """);
+    }
+
+    /** Mixed expression and generic declaration resources. */
+    @Test
+    public void testTwrMixedGenericResources() throws Exception {
+        assertNoInternalError("A.java", """
+                import java.io.*;
+                class A {
+                    static <R extends Closeable> void process(R resource, InputStream extra) throws IOException {
+                        try (R r = resource;
+                             extra) {
+                            System.out.println(r);
+                        }
+                    }
+                }
+                """);
+    }
+
+    // -----------------------------------------------------------------------
+    //  Regression: traditional try-with-resources (should still work)
+    // -----------------------------------------------------------------------
+
+    /** Traditional try-with-resources with a concrete type. */
+    @Test
+    public void testTwrTraditionalResource() throws Exception {
+        assertNoInternalError("A.java", """
+                import java.io.*;
+                class A {
+                    void process(String path) throws IOException {
+                        try (BufferedReader br = new BufferedReader(new FileReader(path))) {
+                            System.out.println(br.readLine());
+                        }
+                    }
+                }
+                """);
+    }
+
+    /** Traditional try-with-resources with multiple resources. */
+    @Test
+    public void testTwrTraditionalMultipleResources() throws Exception {
+        assertNoInternalError("A.java", """
+                import java.io.*;
+                class A {
+                    void copy(String src, String dst) throws IOException {
+                        try (FileInputStream in = new FileInputStream(src);
+                             FileOutputStream out = new FileOutputStream(dst)) {
+                            out.write(in.read());
+                        }
+                    }
+                }
+                """);
+    }
+
+    /** Traditional try-with-resources with inner AutoCloseable class. */
+    @Test
+    public void testTwrTraditionalAutoCloseable() throws Exception {
+        assertNoInternalError("A.java", """
+                class A {
+                    static class MyResource implements AutoCloseable {
+                        public void close() {}
+                    }
+                    void use() {
+                        try (MyResource r = new MyResource()) {
+                            System.out.println(r);
+                        }
+                    }
+                }
+                """);
+    }
+
+    // -----------------------------------------------------------------------
+    //  Edge cases
+    // -----------------------------------------------------------------------
+
+    /** Try-with-resources inside a try-catch. */
+    @Test
+    public void testTwrNestedInTryCatch() throws Exception {
+        assertNoInternalError("A.java", """
+                import java.io.*;
+                class A {
+                    void process(InputStream in) {
+                        try {
+                            try (in) {
+                                in.read();
+                            }
+                        } catch (IOException e) {
+                            // handled
+                        }
+                    }
+                }
+                """);
+    }
+
+    /** Nested try-with-resources. */
+    @Test
+    public void testTwrNestedTryWithResources() throws Exception {
+        assertNoInternalError("A.java", """
+                import java.io.*;
+                class A {
+                    void process(String path) throws IOException {
+                        try (FileInputStream fis = new FileInputStream(path)) {
+                            try (BufferedInputStream bis = new BufferedInputStream(fis)) {
+                                bis.read();
+                            }
+                        }
+                    }
+                }
+                """);
+    }
+
+    // NOTE: intersection type bounds (e.g. <R extends Closeable & Serializable>)
+    // trigger a pre-existing "Mismatched decls" bug in JmlAttr.visitTypeParameter,
+    // which is unrelated to the try-with-resources fixes.  Intersection bound
+    // tests are intentionally omitted.
+}

--- a/OpenJMLTest/src/org/jmlspecs/openjmltest/testsuites/switchparse.java
+++ b/OpenJMLTest/src/org/jmlspecs/openjmltest/testsuites/switchparse.java
@@ -1,0 +1,131 @@
+package org.jmlspecs.openjmltest.testsuites;
+
+import org.jmlspecs.openjmltest.TCBase;
+import org.junit.Test;
+
+@org.junit.FixMethodOrder(org.junit.runners.MethodSorters.NAME_ASCENDING)
+public class switchparse extends TCBase {
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        addOptions("--source", "21");
+        addOptions("--enable-preview", "--enable-preview");
+        addOptions("--check");
+        expectedExit = 0;
+    }
+
+    @Test
+    public void testBindingPatternReference() {
+        helpTCText("A.java",
+                """
+                class A {
+                    int m(Object o) {
+                        return switch (o) {
+                            case String s -> s.length();
+                            default -> 0;
+                        };
+                    }
+                }
+                """);
+    }
+
+    @Test
+    public void testBindingPatternSealedInterface() {
+        helpTCText("A.java",
+                """
+                class A {
+                    sealed interface R permits Ok, Err {}
+                    record Ok(int value) implements R {}
+                    record Err(int value) implements R {}
+                    int m(R r) {
+                        return switch (r) {
+                            case Ok ok -> ok.value();
+                            case Err err -> err.value();
+                        };
+                    }
+                }
+                """);
+    }
+
+    @Test
+    public void testCaseNullAndDefault() {
+        helpTCText("A.java",
+                """
+                class A {
+                    int m(Object o) {
+                        return switch (o) {
+                            case null, default -> 0;
+                        };
+                    }
+                }
+                """);
+    }
+
+    @Test
+    public void testGenericSelectorPatternSwitch() {
+        helpTCText("A.java",
+                """
+                class A<E> {
+                    int m(E e) {
+                        return switch (e) {
+                            case Exception ex -> 1;
+                            default -> 0;
+                        };
+                    }
+                }
+                """);
+    }
+
+    @Test
+    public void testGuardedRecordPatternSwitchExpression() {
+        helpTCText("A.java",
+                """
+                class A {
+                    record Box(int x) {}
+                    int m(Box b) {
+                        return switch (b) {
+                            case Box(int x) when x > 0 -> x;
+                            case Box(int x) -> -x;
+                        };
+                    }
+                }
+                """);
+    }
+
+    @Test
+    public void testRecordPatternSimpleAndNested() {
+        helpTCText("A.java",
+                """
+                class A {
+                    record Bar(int x) {}
+                    record Foo(Bar bar) {}
+                    int m(Foo f) {
+                        return switch (f) {
+                            case Foo(Bar(int x)) -> x;
+                        };
+                    }
+                }
+                """);
+    }
+
+    @Test
+    public void testUnnamedPatterns() {
+        helpTCText("A.java",
+                """
+                class A {
+                    record Foo(int x) {}
+                    int m(Object o, Foo f) {
+                        int a = switch (o) {
+                            case String _, Integer _ -> 1;
+                            default -> 0;
+                        };
+                        int b = switch (f) {
+                            case Foo(_) -> 2;
+                        };
+                        return a + b;
+                    }
+                }
+                """);
+    }
+}

--- a/OpenJMLsrc/src/jdk.compiler/share/classes/org/jmlspecs/openjml/esc/BasicBlockerParent.java
+++ b/OpenJMLsrc/src/jdk.compiler/share/classes/org/jmlspecs/openjml/esc/BasicBlockerParent.java
@@ -794,8 +794,12 @@ abstract public class BasicBlockerParent<T extends BlockParent<T>, P extends Bas
                 List<JCStatement> stats = caseItem.stats;
                 int casepos = caseItem.getStartPosition();
                 
+                // Determine whether this is a true default case (not a pattern case)
+                boolean isDefault = caseItem.getLabels().stream()
+                        .allMatch(l -> l instanceof JCTree.JCDefaultCaseLabel);
+                
                 // create a block for this case test
-                T blockForTest = newBlock(caseValues.isEmpty() ? CASEDEFAULT : CASETEST , casepos);
+                T blockForTest = newBlock(isDefault ? CASEDEFAULT : CASETEST , casepos);
                 blocks.add(blockForTest);
                 follows(switchStart,blockForTest);
                 
@@ -811,11 +815,21 @@ abstract public class BasicBlockerParent<T extends BlockParent<T>, P extends Bas
                 		JCExpression eq = treeutils.makeBinary(caseValue.getStartPosition(),JCTree.Tag.EQ,vdd,(caseValue));
                 		eqq = eqq == null ? eq : treeutils.makeOr(casepos, eqq, eq);
                 	}
+                	// For pattern case labels (JCPatternCaseLabel), getExpressions()
+                	// returns an empty list because it only handles constant labels.
+                	// The actual pattern-matching logic (instanceof checks, bindings)
+                	// has already been desugared into IMPLICIT_ASSUME statements in
+                	// the case body by JmlAssertionAdder.translatePatternLabels().
+                	// We use 'true' here so the CASECONDITION assume is non-null;
+                	// the real guard is in the body assumes.
+                	if (eqq == null && !isDefault) {
+                		eqq = treeutils.trueLit;
+                	}
                 }
                 JmlStatementExpr asm = addAssume(caseItem.pos,Label.CASECONDITION,eqq,blockForTest.statements);
                 
                 // continue to build up the default case test
-                if (caseValues.isEmpty()) defaultAsm = asm; // remember the assumption for the default case
+                if (isDefault) defaultAsm = asm; // remember the assumption for the default case
                 else defaultCond = treeutils.makeOr(caseItem.getStartPosition(),eqq,defaultCond);
 
                 // It is always safe for the value of 'fallthrough' to be true, 

--- a/OpenJMLsrc/src/jdk.compiler/share/classes/org/jmlspecs/openjml/esc/JmlAssertionAdder.java
+++ b/OpenJMLsrc/src/jdk.compiler/share/classes/org/jmlspecs/openjml/esc/JmlAssertionAdder.java
@@ -7351,6 +7351,8 @@ public class JmlAssertionAdder extends JmlTreeScanner {
 
 	// This translation follows
 	// https://docs.oracle.com/javase/specs/jls/se8/html/jls-14.html#jls-ResourceList
+	// Updated to also handle Java 9+ expression resources (JEP 213) and
+	// generic resource types (e.g. <R extends Closeable>).
 	protected void transformTryWithResources(JCTry that) {
 		if (that.resources == null || that.resources.isEmpty()) return;
 
@@ -7359,11 +7361,27 @@ public class JmlAssertionAdder extends JmlTreeScanner {
 		JCTree resource = that.resources.head;
 		List<JCTree> resourceRest = that.resources.tail;
 		int pos = resource.pos;
-		JCVariableDecl decl = (JCVariableDecl) resource;
-		decl.mods.flags |= Flags.FINAL; // implicitly final
+
+		// Bug A fix: Handle both JCVariableDecl resources (traditional syntax:
+		//   try (Type v = expr) {...}) and JCExpression resources (Java 9+ syntax:
+		//   try (existingVar) {...}).  For expression resources, create a synthetic
+		//   final variable initialized from the expression, mirroring the approach
+		//   used in Lower.makeTwrBlock().
+		JCVariableDecl decl;
+		if (resource instanceof JCVariableDecl vd) {
+			decl = vd;
+			decl.mods.flags |= Flags.FINAL; // implicitly final
+		} else {
+			// Java 9+ effectively-final expression resource (JCIdent or JCFieldAccess)
+			JCExpression resExpr = (JCExpression) resource;
+			Name synName = names.fromString("__JMLtwrVar_" + resource.pos);
+			Symbol owner = methodDecl != null ? methodDecl.sym : classDecl.sym;
+			decl = treeutils.makeVarDef(resource.type, synName, owner, resExpr);
+			decl.mods.flags |= Flags.FINAL;
+		}
 
 		ListBuffer<JCStatement> stats = new ListBuffer<>();
-		stats.add((JCStatement) resource);
+		stats.add(decl);
 
 		Name throwableName = names.fromString("__JMLthrowableException_" + resource.pos);
 		JCVariableDecl throwableDecl = treeutils.makeVarDef(syms.throwableType, throwableName,
@@ -7393,7 +7411,27 @@ public class JmlAssertionAdder extends JmlTreeScanner {
 		JCCatch newCatch = M.at(pos).Catch(catchDecl, M.at(pos).Block(0L, List.<JCStatement>of(exStat, exThrow)));
 
 		JCIdent id = treeutils.makeIdent(pos, decl.sym);
-		MethodSymbol msym = findCloseMethod((ClassSymbol) resource.type.tsym);
+		// Bug B fix: When the resource has a generic type (e.g. <R extends Closeable>),
+		// resource.type.tsym is a TypeVariableSymbol, not a ClassSymbol.  Use
+		// types.asSuper() to resolve to the AutoCloseable supertype, which correctly
+		// follows TypeVar upper bounds (Types.java visitTypeVar) and always yields a
+		// ClassSymbol.  For concrete types (already a ClassSymbol), use the original
+		// type directly to preserve the specific close() method resolution.
+		Type resourceType = decl.sym.type;
+		ClassSymbol closeClassSym;
+		if (resourceType.tsym instanceof ClassSymbol cs) {
+			closeClassSym = cs;
+		} else {
+			// TypeVariableSymbol or other non-ClassSymbol: resolve through bounds
+			Type autoCloseableSuper = types.asSuper(resourceType, syms.autoCloseableType.tsym);
+			if (autoCloseableSuper != null && autoCloseableSuper.tsym instanceof ClassSymbol cs2) {
+				closeClassSym = cs2;
+			} else {
+				// Last resort fallback
+				closeClassSym = (ClassSymbol) syms.autoCloseableType.tsym;
+			}
+		}
+		MethodSymbol msym = findCloseMethod(closeClassSym);
 		M.at(pos);
 		JCExpression fcn1 = M.Select(id, msym);
 		fcn1.type = msym.type;

--- a/OpenJMLsrc/src/jdk.compiler/share/classes/org/jmlspecs/openjml/esc/JmlAssertionAdder.java
+++ b/OpenJMLsrc/src/jdk.compiler/share/classes/org/jmlspecs/openjml/esc/JmlAssertionAdder.java
@@ -1279,6 +1279,36 @@ public class JmlAssertionAdder extends JmlTreeScanner {
 					JCStatement s = iter.next();
 					convert(s);
 				} // TODO: Warn if continuation is EXIT and there are remaining statements?
+
+				// === Record compact constructor implicit field assignments ===
+				// In record compact constructors, the compiler (Lower.java) appends
+				// this.field = param for each record component AFTER the user body.
+				// Lower runs after ESC, so we must synthesize assume this.field == param here.
+				if (isConstructor && esc
+						&& ((methodDecl.sym.flags() & Flags.COMPACT_RECORD_CONSTRUCTOR) != 0
+							|| ((methodDecl.sym.flags() & (Flags.GENERATEDCONSTR | Flags.RECORD))
+									== (Flags.GENERATEDCONSTR | Flags.RECORD)))) {
+					addStat(comment(methodDecl,
+							"Record component field assignments (implicit)", null));
+					for (Symbol sym : classDecl.sym.getEnclosedElements()) {
+						if (sym.kind == Kinds.Kind.VAR
+								&& (sym.flags() & Flags.RECORD) != 0) {
+							for (JCVariableDecl param : methodDecl.params) {
+								if (param.name == sym.name) {
+									JCExpression field =
+											treeutils.makeIdent(param.pos, sym);
+									field = convertJML(field);
+									JCExpression paramExpr =
+											treeutils.makeIdent(param.pos, param.sym);
+									addAssumeEqual(param.pos(),
+											Label.IMPLICIT_ASSUME, field, paramExpr);
+									break;
+								}
+							}
+						}
+					}
+				}
+
                 // FIXME - don't know whether execution is still alive here
 				// addAssumeCheck(methodDecl.body, currentStatements, Strings.feas_return, "at fall-through return");
 				if (continuation == Continuation.CONTINUE) {

--- a/OpenJMLsrc/src/jdk.compiler/share/classes/org/jmlspecs/openjml/esc/JmlAssertionAdder.java
+++ b/OpenJMLsrc/src/jdk.compiler/share/classes/org/jmlspecs/openjml/esc/JmlAssertionAdder.java
@@ -6974,40 +6974,175 @@ public class JmlAssertionAdder extends JmlTreeScanner {
 	
 	@Override
 	public void visitSwitchExpression(JCSwitchExpression that) {
-        addStat(traceableComment(that, that, "switch " + that.getExpression() + " ...", "Selection"));
-        currentEnv = currentEnv.pushEnvCopy();
-        try {
-            currentEnv.yieldIdent = treeutils.makeIdent(that.pos,  "`switchResult_"+nextUnique(), that.type);
-            if (splitExpressions) {
-                addStat(switchHelper(that, true, that.selector, that.cases).setType(that.type));
-                result = eresult = currentEnv.yieldIdent;
-            } else {
-                notImplemented(that,  "Switch expression in a quantified expression");
-            }
-        } finally {
-            currentEnv = currentEnv.popEnv();
-        }
-    }
+	    addStat(traceableComment(that, that, "switch " + that.getExpression() + " ...", "Selection"));
+	    currentEnv = currentEnv.pushEnvCopy();
+	    try {
+	        currentEnv.yieldIdent = treeutils.makeIdent(that.pos,  "`switchResult_"+nextUnique(), that.type);
+	        if (splitExpressions) {
+	            addStat(switchHelper(that, that.isExhaustive, that.selector, that.cases).setType(that.type));
+	            result = eresult = currentEnv.yieldIdent;
+	        } else {
+	            notImplemented(that,  "Switch expression in a quantified expression");
+	        }
+	    } finally {
+	        currentEnv = currentEnv.popEnv();
+	    }
+	}
 	
-	public JCExpression switchCheck(JCExpression switchExpr) {
-        JCExpression selector = convertExpr(switchExpr);
-        // FIXME - will need fixing for pattern matching
-        if (selector.type.equals(syms.stringType)) {
-            JCExpression e = treeutils.makeNeqObject(switchExpr.pos, selector, treeutils.nullLit);
-            addJavaCheck(switchExpr, e, Label.POSSIBLY_NULL_VALUE, Label.POSSIBLY_NULL_VALUE,
-                                    "java.lang.NullPointerException");
-        } else if ((switchExpr.type.tsym.flags_field & Flags.ENUM) != 0) {
-            JCExpression e = treeutils.makeNeqObject(switchExpr.pos, selector, treeutils.nullLit);
-            addJavaCheck(switchExpr, e, Label.POSSIBLY_NULL_VALUE, Label.POSSIBLY_NULL_VALUE,
-                                    "java.lang.NullPointerException");
-        } else {
-            selector = addImplicitConversion(switchExpr, syms.intType, selector);
-        }
-        return selector;
+	protected boolean hasNullCase(List<JCCase> cases) {
+	    for (JCCase c: cases) {
+	        for (JCCaseLabel l: c.labels) {
+	            if (TreeInfo.isNullCaseLabel(l)) return true;
+	        }
+	    }
+	    return false;
+	}
+
+	public JCExpression switchCheck(JCExpression switchExpr, List<JCCase> cases) {
+	    JCExpression selector = convertExpr(switchExpr);
+	    boolean hasNullCase = hasNullCase(cases);
+	    if (selector.type.equals(syms.stringType)) {
+	        if (!hasNullCase) {
+	            JCExpression e = treeutils.makeNeqObject(switchExpr.pos, selector, treeutils.nullLit);
+	            addJavaCheck(switchExpr, e, Label.POSSIBLY_NULL_VALUE, Label.POSSIBLY_NULL_VALUE,
+	                                    "java.lang.NullPointerException");
+	        }
+	    } else if ((switchExpr.type.tsym.flags_field & Flags.ENUM) != 0) {
+	        if (!hasNullCase) {
+	            JCExpression e = treeutils.makeNeqObject(switchExpr.pos, selector, treeutils.nullLit);
+	            addJavaCheck(switchExpr, e, Label.POSSIBLY_NULL_VALUE, Label.POSSIBLY_NULL_VALUE,
+	                                    "java.lang.NullPointerException");
+	        }
+	    } else if (!switchExpr.type.isPrimitive()) {
+	        if (!hasNullCase) {
+	            JCExpression e = treeutils.makeNeqObject(switchExpr.pos, selector, treeutils.nullLit);
+	            addJavaCheck(switchExpr, e, Label.POSSIBLY_NULL_VALUE, Label.POSSIBLY_NULL_VALUE,
+	                                    "java.lang.NullPointerException");
+	        }
+	    } else {
+	        selector = addImplicitConversion(switchExpr, syms.intType, selector);
+	    }
+	    return selector;
+	}
+
+	protected void translatePatternBindings(JCCase caze, JCExpression selector) {
+	    for (JCCaseLabel label: caze.labels) {
+	        if (label instanceof JCPatternCaseLabel patLabel) {
+	            translatePattern(patLabel.pat, selector);
+	        }
+	    }
+	}
+
+	protected void translatePatternLabels(JCCase caze, JCExpression selector) {
+	    translatePatternBindings(caze, selector);
+	    if (caze.guard != null) {
+	        JCExpression guardExpr = addImplicitConversion(caze.guard, syms.booleanType, convertExpr(caze.guard));
+	        addAssume(caze.guard, Label.IMPLICIT_ASSUME, guardExpr);
+	    }
+	}
+
+	protected void translatePattern(JCPattern pattern, JCExpression expr) {
+	    if (pattern instanceof JCBindingPattern bpat) {
+	        if (bpat.var.sym != null && bpat.var.sym.isUnnamedVariable()) return;
+	        if (!splitExpressions) {
+	            notImplementedW(pattern, "binding pattern in this location");
+	            return;
+	        }
+	        var stat = convert(bpat.var);
+	        JCTree clazz = treeutils.makeType(pattern.pos, types.erasure(bpat.type));
+	        JCExpression typeTest = M.at(pattern).TypeTest(copy(expr), clazz);
+	        typeTest.setType(syms.booleanType);
+	        addAssume(pattern, Label.IMPLICIT_ASSUME, typeTest);
+	        JCIdent id = M.at(stat).Ident(bpat.var.sym);
+	        JCExpression eq = treeutils.makeEquality(pattern.getPreferredPosition(), id, expr);
+	        addAssume(pattern, Label.IMPLICIT_ASSUME, eq);
+	    } else if (pattern instanceof JCRecordPattern recPat) {
+	        if (rac) {
+	            notImplemented(pattern, "record pattern in RAC");
+	            return;
+	        }
+	        translateRecordPattern(recPat, expr);
+	    } else if (pattern instanceof JCAnyPattern) {
+	        return;
+	    } else {
+	        notImplemented(pattern, "unsupported pattern kind: " + pattern.getClass().getSimpleName());
+	    }
+	}
+
+	protected void translateRecordPattern(JCRecordPattern recPat, JCExpression expr) {
+	    Type recordType = types.erasure(recPat.record.type);
+	    JCTree clazz = treeutils.makeType(recPat.pos, recordType);
+	    JCExpression typeTest = M.at(recPat).TypeTest(copy(expr), clazz);
+	    typeTest.setType(syms.booleanType);
+	    addAssume(recPat, Label.IMPLICIT_ASSUME, typeTest);
+
+	    JCExpression castExpr = M.at(recPat).TypeCast(recordType, copy(expr));
+	    castExpr.setType(recordType);
+	    JCIdent recTemp = newTemp(castExpr);
+
+	    List<? extends RecordComponent> components = recPat.record.getRecordComponents();
+	    List<JCPattern> nestedPatterns = recPat.nested;
+
+	    while (components.nonEmpty() && nestedPatterns.nonEmpty()) {
+	        RecordComponent component = components.head;
+	        JCPattern nestedPattern = nestedPatterns.head;
+	        JCExpression accessorCall = createAccessorCall(recPat, recTemp, component);
+	        JCIdent compTemp = newTemp(accessorCall);
+	        translatePattern(nestedPattern, compTemp);
+	        components = components.tail;
+	        nestedPatterns = nestedPatterns.tail;
+	    }
+	}
+
+	protected JCExpression createAccessorCall(DiagnosticPosition pos, JCExpression receiver,
+	        RecordComponent component) {
+	    MethodSymbol accessor = component.accessor;
+	    JCFieldAccess select = M.at(pos).Select(copy(receiver), accessor.name);
+	    select.type = accessor.type;
+	    select.sym = accessor;
+	    JCMethodInvocation call = M.at(pos).Apply(List.<JCExpression>nil(), select, List.<JCExpression>nil());
+	    call.setType(types.erasure(accessor.getReturnType()));
+	    return call;
+	}
+
+	protected JCExpression buildPatternCondition(JCPattern pattern, JCExpression expr) {
+	    if (pattern instanceof JCBindingPattern bpat) {
+	        JCTree clazz = treeutils.makeType(pattern.pos, types.erasure(bpat.type));
+	        JCExpression typeTest = M.at(pattern).TypeTest(copy(expr), clazz);
+	        typeTest.setType(syms.booleanType);
+	        return typeTest;
+	    } else if (pattern instanceof JCRecordPattern recPat) {
+	        Type recordType = types.erasure(recPat.record.type);
+	        JCTree clazz = treeutils.makeType(pattern.pos, recordType);
+	        JCExpression condition = M.at(pattern).TypeTest(copy(expr), clazz);
+	        condition.setType(syms.booleanType);
+	        List<? extends RecordComponent> components = recPat.record.getRecordComponents();
+	        List<JCPattern> nestedPatterns = recPat.nested;
+	        JCExpression castExpr = M.at(recPat).TypeCast(recordType, copy(expr));
+	        castExpr.setType(recordType);
+	        JCIdent recTemp = newTemp(castExpr);
+	        while (components.nonEmpty() && nestedPatterns.nonEmpty()) {
+	            RecordComponent component = components.head;
+	            JCPattern nested = nestedPatterns.head;
+	            if (!(nested instanceof JCAnyPattern)) {
+	                JCExpression accessorCall = createAccessorCall(recPat, recTemp, component);
+	                JCExpression nestedCond = buildPatternCondition(nested, accessorCall);
+	                condition = treeutils.makeAnd(pattern, condition, nestedCond);
+	            }
+	            components = components.tail;
+	            nestedPatterns = nestedPatterns.tail;
+	        }
+	        return condition;
+	    } else if (pattern instanceof JCAnyPattern) {
+	        return treeutils.makeBooleanLiteral(pattern, true);
+	    } else {
+	        notImplemented(pattern, "pattern condition for: " + pattern.getClass().getSimpleName());
+	        return treeutils.makeBooleanLiteral(pattern, true);
+	    }
 	}
 	
 	public JCSwitch switchHelper(DiagnosticPosition pos, boolean isExhaustive, JCExpression switchExpr, List<JCCase> cases) {
-	    JCExpression selector = switchCheck(switchExpr);
+	    JCExpression selector = switchCheck(switchExpr, cases);
 	    JCSwitch newswitch = M.at(pos).Switch(selector, null); // cases filled in later, but we need the new tree reference now
 	    // treeMap is used to map break statements to their target statements
         treeMap.put((JCTree)pos, newswitch); // pos must also be the  JCSwitch or JCSwitchExpression
@@ -7026,6 +7161,11 @@ public class JmlAssertionAdder extends JmlTreeScanner {
 	            boolean isArrow = _case.caseKind != com.sun.source.tree.CaseTree.CaseKind.STATEMENT;
 
 	            pushBlock();
+	            if (((JCTree)pos instanceof JCSwitch sw && sw.patternSwitch)
+	                    || ((JCTree)pos instanceof JCSwitchExpression swexpr && swexpr.patternSwitch)
+	                    || _case.labels.stream().anyMatch(l -> l instanceof JCPatternCaseLabel)) {
+	                translatePatternLabels(_case, selector);
+	            }
 	            addFeasibilityCheck(_case, currentStatements, Strings.feas_switch, "after case condition");
 	            convert(_case.stats); // This might change 'continuation'
 	            if (isArrow && _case.completesNormally) {
@@ -7081,7 +7221,7 @@ public class JmlAssertionAdder extends JmlTreeScanner {
 		    // record the translation from old to new AST  // FIXME - this used to be before trabnslating the body. Does it matter?
 		    result = addStat(newSwitch.setType(that.type)); // But actually, statements do not have a type
 		} else {
-	        JCExpression selector = switchCheck(that.selector);
+	        JCExpression selector = switchCheck(that.selector, that.cases);
 	        JCSwitch newswitch = M.at(that).Switch(selector, null); // cases filled in later, but we need the new tree reference now
 	        // treeMap is used to map break statements to their target statements
 	        treeMap.put(that, newswitch); // pos must also be the  JCSwitch or JCSwitchExpression
@@ -7098,15 +7238,37 @@ public class JmlAssertionAdder extends JmlTreeScanner {
 		    }
 
 		    JCCase caseToDo = doCase < that.cases.size() ? that.cases.get(doCase) : null;
+		    if (caseToDo == null && that.cases.stream().anyMatch(c -> c.guard != null
+		            && c.labels.stream().anyMatch(l -> l instanceof JCPatternCaseLabel))) {
+		        popBlock(that);
+		        treeMap.remove(that);
+		        notImplementedW(that, "split switch translation for default with guarded pattern cases");
+		        JCSwitch newSwitch = switchHelper(that, that.isExhaustive, that.selector, that.cases);
+		        ((JmlSwitchStatement) newSwitch).split = ((JmlSwitchStatement) that).split;
+		        result = addStat(newSwitch.setType(that.type));
+		        return;
+		    }
 		    // caseToDo == null when the original switch has no default case -- so skip everything if no case condition matches
 		    // FIXME - only works for traditional enums or ints, not strings or patterns
 		    JCExpression caseCondition = null;
+		    boolean translatedSelectedBindings = false;
 		    if (caseToDo != null && !caseToDo.labels.isEmpty()) {
+		        if (caseToDo.guard != null && caseToDo.labels.stream().anyMatch(l -> l instanceof JCPatternCaseLabel)) {
+		            translatePatternBindings(caseToDo, selector);
+		            translatedSelectedBindings = true;
+		        }
 		        for (JCCaseLabel pat : caseToDo.labels) {
 	        		if (pat instanceof JCConstantCaseLabel patc) {
 	        			JCExpression e = treeutils.makeEquality(pat.pos, selector, convertExpr(patc.expr));
 	        			caseCondition = caseCondition == null ? e : treeutils.makeOr(that, caseCondition, e);
+	        		} else if (pat instanceof JCPatternCaseLabel patLabel) {
+	        			JCExpression e = buildPatternCondition(patLabel.pat, selector);
+	        			caseCondition = caseCondition == null ? e : treeutils.makeOr(that, caseCondition, e);
 	        		}
+		        }
+		        if (caseToDo.guard != null) {
+		            JCExpression guardExpr = addImplicitConversion(caseToDo.guard, syms.booleanType, convertExpr(caseToDo.guard));
+		            caseCondition = caseCondition == null ? guardExpr : treeutils.makeAnd(that, caseCondition, guardExpr);
 		        }
 		    } else {
 		        // default
@@ -7114,11 +7276,22 @@ public class JmlAssertionAdder extends JmlTreeScanner {
 		        	for (var pat : c.labels) {
 		        		if (pat instanceof JCConstantCaseLabel patc) {
 		                    JCExpression e = treeutils.makeEquality(pat.pos, copy(selector), convertExpr(patc.expr));
+		                    if (c.guard != null) {
+		                        JCExpression guardExpr = addImplicitConversion(c.guard, syms.booleanType, convertExpr(c.guard));
+		                        e = treeutils.makeAnd(that, e, guardExpr);
+		                    }
 		                    caseCondition = caseCondition == null ? e : treeutils.makeOr(that, caseCondition, e);
+		        		} else if (pat instanceof JCPatternCaseLabel patLabel) {
+		        			JCExpression e = buildPatternCondition(patLabel.pat, copy(selector));
+		        			if (c.guard != null) {
+		        			    JCExpression guardExpr = addImplicitConversion(c.guard, syms.booleanType, convertExpr(c.guard));
+		        			    e = treeutils.makeAnd(that, e, guardExpr);
+		        			}
+		        			caseCondition = caseCondition == null ? e : treeutils.makeOr(that, caseCondition, e);
 		        		}
 		            }
 		        }
-		        caseCondition = treeutils.makeNot(that, caseCondition);
+		        if (caseCondition != null) caseCondition = treeutils.makeNot(that, caseCondition);
 		    }
 
 		    if (caseCondition != null) {
@@ -7126,6 +7299,9 @@ public class JmlAssertionAdder extends JmlTreeScanner {
 	            addFeasibilityCheck(caseToDo, currentStatements, Strings.feas_switch, "after case condition");
 		    }
 		    if (caseToDo != null) {
+		        if (!translatedSelectedBindings && (that.patternSwitch || caseToDo.labels.stream().anyMatch(l -> l instanceof JCPatternCaseLabel))) {
+		            translatePatternLabels(caseToDo, selector);
+		        }
 		        convert(caseToDo.stats);
 		        doCase++;
 		        while (doCase < that.cases.size() && caseToDo.completesNormally) {
@@ -7842,7 +8018,9 @@ public class JmlAssertionAdder extends JmlTreeScanner {
 	public void visitYield(JCYield that) {
 	    if (currentEnv.yieldIdent != null) {
 	        var e = convertExpr(that.value);
-            e = addImplicitConversion(that, currentEnv.yieldIdent.type, e);
+	        if (!types.isSameType(currentEnv.yieldIdent.type, e.type)) {
+	            e = addImplicitConversion(that, currentEnv.yieldIdent.type, e);
+	        }
 	        addStat(treeutils.makeAssignStat(that.pos, copy(currentEnv.yieldIdent), e));
 	        addStat(M.at(that.pos).Break(null));
 	    } else {
@@ -9219,18 +9397,18 @@ public class JmlAssertionAdder extends JmlTreeScanner {
                 // No casts - obscures the fact that the atranslated arg is a JCLambda
                 // also a.type ihas type variables resolved
                 // Just continue
-            } else {
-                //System.out.println("ARGCONVERSION " + a.type + " " + currentArgType);
-                // The 'rac' disjunct is needed for tests like racHans4c/d/e
-                // The other disjunct is needed for test implicitIterationA
-                var convtype = rac ? currentArgType : convertType(currentArgType);
-                if (rac || (a.type.isPrimitive() || types.isNumeric(a.type) 
-                        || currentArgType.isPrimitive() || types.isNumeric(currentArgType) || types.isJmlType(convtype))) {
-                    //System.out.println("ADDING IMPLICIT-A " + currentArgType + " " + convtype + " " + a + " " + a.type);
-                    a = addImplicitConversion(a, convtype, a);
-                    //System.out.println("   CONVERTED " + a);
-                }
-            }
+			} else {
+				//System.out.println("ARGCONVERSION " + a.type + " " + currentArgType);
+				// The 'rac' disjunct is needed for tests like racHans4c/d/e
+				// The other disjunct is needed for test implicitIterationA
+				var convtype = currentArgType == null ? null : (rac ? currentArgType : convertType(currentArgType));
+				if (convtype != null && a != null && a.type != null && (rac || (a.type.isPrimitive() || types.isNumeric(a.type) 
+						|| currentArgType.isPrimitive() || types.isNumeric(currentArgType) || types.isJmlType(convtype)))) {
+					//System.out.println("ADDING IMPLICIT-A " + currentArgType + " " + convtype + " " + a + " " + a.type);
+					a = addImplicitConversion(a, convtype, a);
+					//System.out.println("   CONVERTED " + a);
+				}
+			}
 			if (useMethodAxioms && translatingJML) {
 			} else if ((a instanceof JCIdent) && ((JCIdent) a).name.toString().startsWith(Strings.tmpVarString)) {
 			} else if ((a instanceof JCIdent) && localVariables.containsKey(((JCIdent) a).sym)) {
@@ -15061,9 +15239,18 @@ public class JmlAssertionAdder extends JmlTreeScanner {
             }
             result = eresult = e;
             return;
-        } else if (optag == JCTree.Tag.PLUS && that.type.equals(syms.stringType)) {
+		} else if (optag == JCTree.Tag.PLUS && that.type.equals(syms.stringType)) {
 			if ((infer || esc)) {
-				Symbol s = utils.findStaticMember(syms.stringType.tsym, "concat");
+				Symbol s = null;
+				Name concatName = names.fromString("concat");
+				x: for (Symbol ss: syms.stringType.tsym.getEnclosedElements()) {
+					if (!ss.isStatic() && ss instanceof MethodSymbol ms && ss.name.equals(concatName)) {
+						if (ms.params.length() != 1) continue;
+						if (!types.isSameType(ms.params.head.type, syms.stringType)) continue x;
+						s = ss;
+						break;
+					}
+				}
 				if (s == null) {
 					utils.error(that, "jml.internal", "Could not find the concat method");
 				} else {
@@ -15090,10 +15277,10 @@ public class JmlAssertionAdder extends JmlTreeScanner {
 						call.type = call.sym.type;
 						rhs = M.at(that).Apply(null, call, List.<JCExpression>of(rhs)).setType(syms.stringType);
 					}
-					JCFieldAccess call = M.Select(id, names.fromString("concat"));
+					JCFieldAccess call = M.Select(lhs, concatName);
 					call.sym = s;
 					call.type = s.type;
-					JCMethodInvocation m = M.at(that).Apply(null, call, List.<JCExpression>of(lhs, rhs))
+					JCMethodInvocation m = M.at(that).Apply(null, call, List.<JCExpression>of(rhs))
 							.setType(that.type);
 					result = eresult = convertExpr(m);
 				}


### PR DESCRIPTION
This builds on #951 and sketches out a solution for handling implicit record fields in the compact constructors of Records.  Some of this is discussed in #819 .

With this change, it's enough to mark the fields of a record as `/*@ non_null */`, use the compact constructor with `Objects.requireNonNull(...)`, and have OpenJML bridge it all together during verification.

When stacked on top of the other changes (switch statements, try-with-resources, etc.), it's possible to process `Result.java` (attached as an example).
[Result.java](https://github.com/user-attachments/files/26508401/Result.java)
